### PR TITLE
Propagate DDNS update result to script exit

### DIFF
--- a/ddns-route53
+++ b/ddns-route53
@@ -124,7 +124,7 @@ EOF
 
 function run-handler-script() {
   local old_ip=$1 new_ip=$2
-  [[ -n "$handler_script" ]] && "$handler_script" "$old_ip" "$new_ip"
+  [[ -z "$handler_script" ]] || "$handler_script" "$old_ip" "$new_ip"
 }
 
 function main() {

--- a/ddns-route53
+++ b/ddns-route53
@@ -140,7 +140,7 @@ function main() {
   else
     log "Current IP == $ip"
   fi
-  exit 0
+  exit $?
 }
 
 main "$@"


### PR DESCRIPTION
Using this script in a service, and would like to know when the Route53 update actually fails.

Run-handler-script should return 0 if no script is defined, or the output of the handler script.