### PR TITLE
EC2 private IP and multiple IP updates

### DIFF
--- a/ddns-route53
+++ b/ddns-route53
@@ -29,7 +29,7 @@ Options:
   -z, --zone-id <ZONE_ID>         Amazon Route53 hosted zone ID (required)
   -r, --record-set <RECORD_SET>   Amazon Route53 record set name (required)
   -t, --ttl <SECONDS>             TTL for DNS record
-  -p, --private                   Private address lookup
+  -p, --private                   Private address lookup(ec2 only)
   -y, --type <TYPE>               DNS record type
   -i, --ip <IP_ADDRESS>           Force usage of IP address
   -s, --script <SCRIPT_PATH>      Path to script to execute on change
@@ -86,22 +86,35 @@ function init-args() {
 function validate-args() {
   if [[ -z "$zone_id" ]]; then
     errlog "Missing -z or --zone-id or \$DDNS_ROUTE53_ZONE_ID"
+    usage
     return 1
   elif [[ -z "$record_set" ]]; then
     errlog "Missing -r or --record-set or \$DDNS_ROUTE53_RECORD_SET"
+    usage
     return 1
   elif [[ -n "$handler_script" && ! -x "$handler_script" ]]; then
     errlog "Script at '$handler_script' is not executable"
+    usage
     return 1
   elif [[ -z "$ip" ]]; then
     errlog "Unable to determine current IP address"
+    usage
     return 1
   fi
   return 0
 }
 
 function update-dns-entry() {
-  local ip=$1 output success batch
+  local list=$1 output success batch
+  count=0
+  for ip in $list; do
+    if [[ $count -eq 0 ]]; then
+      value="{\"Value\": \"$ip\"}"
+    else
+      value="${value},{\"Value\": \"$ip\"}"
+    fi
+    ((count++))
+  done
   read -r -d '' batch << EOF
 {
   "Comment": "$comment",
@@ -109,7 +122,7 @@ function update-dns-entry() {
     {
       "Action": "UPSERT",
       "ResourceRecordSet": {
-        "ResourceRecords": [{"Value": "$ip"}],
+        "ResourceRecords": [$value],
         "Name": "$record_set",
         "Type": "$record_type",
         "TTL": $ttl

--- a/ddns-route53
+++ b/ddns-route53
@@ -9,6 +9,7 @@ declare zone_id="$DDNS_ROUTE53_ZONE_ID"
 declare record_set="$DDNS_ROUTE53_RECORD_SET"
 declare handler_script="$DDNS_ROUTE53_SCRIPT"
 declare old_ip ip
+declare private=false
 
 function errlog() {
   echo "$@" >&2
@@ -28,6 +29,7 @@ Options:
   -z, --zone-id <ZONE_ID>         Amazon Route53 hosted zone ID (required)
   -r, --record-set <RECORD_SET>   Amazon Route53 record set name (required)
   -t, --ttl <SECONDS>             TTL for DNS record
+  -p, --private                   Private address lookup
   -y, --type <TYPE>               DNS record type
   -i, --ip <IP_ADDRESS>           Force usage of IP address
   -s, --script <SCRIPT_PATH>      Path to script to execute on change
@@ -61,6 +63,7 @@ function init-args() {
       -r|--record-set) record_set="$2"; shift ;;
       -i|--ip) ip="$2"; shift ;;
       -t|--ttl) ttl="$2"; shift ;;
+      -p|--private) private=true; shift ;;
       -y|--type) record_type="$2"; shift ;;
       -s|--script) handler_script="$2"; shift ;;
       -h|--help) usage; exit 0 ;;
@@ -70,7 +73,11 @@ function init-args() {
     shift
   done
   if [[ -z "$ip" ]]; then
-    ip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    if [[ $private == true ]]; then
+      ip="$(curl http://169.254.169.254/latest/meta-data/local-ipv4)"
+    else
+      ip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    fi
   fi
   old_ip="$(fetch-current-ip 2> /dev/null)"
   return 0

--- a/ddns-route53
+++ b/ddns-route53
@@ -86,19 +86,15 @@ function init-args() {
 function validate-args() {
   if [[ -z "$zone_id" ]]; then
     errlog "Missing -z or --zone-id or \$DDNS_ROUTE53_ZONE_ID"
-    usage
     return 1
   elif [[ -z "$record_set" ]]; then
     errlog "Missing -r or --record-set or \$DDNS_ROUTE53_RECORD_SET"
-    usage
     return 1
   elif [[ -n "$handler_script" && ! -x "$handler_script" ]]; then
     errlog "Script at '$handler_script' is not executable"
-    usage
     return 1
   elif [[ -z "$ip" ]]; then
     errlog "Unable to determine current IP address"
-    usage
     return 1
   fi
   return 0


### PR DESCRIPTION
Not sure if you want these or not but they have been useful for me so far.   

`-p` will pull the ec2 instance private IP instead of the public IP

`-i "1.1.1.1 2.2.2.2 3.3.3.3"`  will update the record for simple query round robin

`-i` will still handle single addresses as well without issue. 
