### PR TITLE
Support IPv6 resolvers by forcing IPv4 on the connection

### DIFF
--- a/ddns-route53
+++ b/ddns-route53
@@ -70,7 +70,7 @@ function init-args() {
     shift
   done
   if [[ -z "$ip" ]]; then
-    ip="$(dig +short myip.opendns.com @resolver1.opendns.com)"
+    ip="$(dig +short -4 myip.opendns.com @resolver1.opendns.com)"
   fi
   old_ip="$(fetch-current-ip 2> /dev/null)"
   return 0


### PR DESCRIPTION
If `resolver1.opendns.com` is contacted over IPv6, DDNS's query for the "A" record of "myip.opendns.com" will fail and return NXDOMAIN, since the DNS server doesn't know your IPv4 address in that case. This causes the script to fail with "Unable to determine current IP address". For me, `resolver1.opendns.com` currently resolves to `2620:119:35::35`.

This patch adds "-4" to the arguments to dig to make sure it contacts the resolver over IPv4, which fixes the issue.