### PR TITLE
Fix bug in ip validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
-language: bash
-dist: trusty
-addons:
-  apt:
-    sources:
-      - sourceline: "deb http://archive.ubuntu.com/ubuntu/ trusty-backports universe"
-    packages:
-      - shellcheck
+language: shell
+dist: bionic
+
 script:
-  - shellcheck $(find . -maxdepth 1 -type f -executable)
+  - shellcheck ddns-route53

--- a/ddns-route53
+++ b/ddns-route53
@@ -40,7 +40,7 @@ function valid-ip() {
   local ip=$1 octets
   if [[ "$ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
     IFS='.' read -r -a octets <<< "$ip"
-    for octet in $octets; do
+    for octet in "${octets[@]}"; do
       (( octet <= 255 )) || return 1
     done
   fi


### PR DESCRIPTION
I also updated the travis file to use the built-in shellcheck to avoid installing it.
